### PR TITLE
Added appropriate public module imports.

### DIFF
--- a/deimos/alsa/output.d
+++ b/deimos/alsa/output.d
@@ -1,6 +1,6 @@
 module deimos.alsa.output;
 
-import core.sys.posix.sys.types : ssize_t;
+public import core.sys.posix.sys.types : ssize_t;
 import core.stdc.stdio : FILE;
 import core.stdc.stdarg : va_list;
 


### PR DESCRIPTION
This project relies on currently deprecated module import bugs.
More info can be found at http://www.schveiguy.com/blog/2016/03/import-changes-in-d-2-071/.
